### PR TITLE
Fix image sizing in how-to-plan page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -822,8 +822,7 @@ strong {
 
 .app-screenshot {
     display: block;
-    max-width: 300px;
-    width: 100%;
+    width: auto;
     height: auto;
     margin: var(--space-lg) auto;
     border-radius: var(--radius-md);
@@ -831,15 +830,10 @@ strong {
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.app-screenshot-wide {
-    display: block;
-    max-width: 100%;
-    width: 100%;
-    height: auto;
-    margin: var(--space-lg) auto;
-    border-radius: var(--radius-md);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+@media (max-width: 768px) {
+    .app-screenshot {
+        width: 100%;
+    }
 }
 
 img {

--- a/how-to-plan.html
+++ b/how-to-plan.html
@@ -76,7 +76,7 @@ description: "Learn how to create a financial plan in Finance Planner. Step-by-s
             <h2 class="animate-from-right">Step 3: Planning Mortgages</h2>
             <p>Mortgages are a specific type of expense where the monthly payment is calculated based on the loan amount, interest rate, and repayment schedule. You can also model mortgage interest tax deductions. Here's how to configure a mortgage:</p>
             
-            <img src="https://github.com/user-attachments/assets/8b7c5f7b-d0b5-459b-b61e-ab5ee35ee2d3" alt="Mortgage planning screen in Finance Planner app" class="app-screenshot-wide">
+            <img src="https://github.com/user-attachments/assets/8b7c5f7b-d0b5-459b-b61e-ab5ee35ee2d3" alt="Mortgage planning screen in Finance Planner app" class="app-screenshot">
             <p class="screenshot-caption">The Mortgage screen showing all configuration options with numbered annotations</p>
             
             <div class="example-files-list">
@@ -115,7 +115,7 @@ description: "Learn how to create a financial plan in Finance Planner. Step-by-s
             <h2 class="animate-from-left">Step 4: Planning Expenses</h2>
             <p>Expenses are a crucial part of your financial plan. When you plan your expenses, you can see what you need to do to achieve your financial goals. Here's how to configure an expense:</p>
             
-            <img src="https://github.com/user-attachments/assets/69e1eead-87d2-4cb1-8ec6-0e972580a698" alt="Expense planning screen in Finance Planner app" class="app-screenshot-wide">
+            <img src="https://github.com/user-attachments/assets/69e1eead-87d2-4cb1-8ec6-0e972580a698" alt="Expense planning screen in Finance Planner app" class="app-screenshot">
             <p class="screenshot-caption">The Expense screen showing all configuration options with numbered annotations</p>
             
             <div class="example-files-list">

--- a/nl/how-to-plan.html
+++ b/nl/how-to-plan.html
@@ -76,7 +76,7 @@ description: "Leer hoe je een financieel plan maakt in Finance Planner. Stapsgew
             <h2 class="animate-from-right">Stap 3: Hypotheken plannen</h2>
             <p>Hypotheken zijn een specifiek type uitgave waarbij de maandelijkse betaling wordt berekend op basis van het leningbedrag, de rente en het aflossingsschema. Je kunt ook hypotheekrenteaftrek modelleren. Zo configureer je een hypotheek:</p>
             
-            <img src="https://github.com/user-attachments/assets/8b7c5f7b-d0b5-459b-b61e-ab5ee35ee2d3" alt="Mortgage planning screen in Finance Planner app" class="app-screenshot-wide">
+            <img src="https://github.com/user-attachments/assets/8b7c5f7b-d0b5-459b-b61e-ab5ee35ee2d3" alt="Mortgage planning screen in Finance Planner app" class="app-screenshot">
             <p class="screenshot-caption">Het Hypotheek scherm met alle configuratie-opties en genummerde annotaties</p>
             
             <div class="example-files-list">
@@ -115,7 +115,7 @@ description: "Leer hoe je een financieel plan maakt in Finance Planner. Stapsgew
             <h2 class="animate-from-left">Stap 4: Uitgaven plannen</h2>
             <p>Uitgaven zijn een cruciaal onderdeel van je financiële plan. Wanneer je je uitgaven plant, kun je zien wat je moet doen om je financiële doelen te bereiken. Zo configureer je een uitgave:</p>
             
-            <img src="https://github.com/user-attachments/assets/69e1eead-87d2-4cb1-8ec6-0e972580a698" alt="Expense planning screen in Finance Planner app" class="app-screenshot-wide">
+            <img src="https://github.com/user-attachments/assets/69e1eead-87d2-4cb1-8ec6-0e972580a698" alt="Expense planning screen in Finance Planner app" class="app-screenshot">
             <p class="screenshot-caption">Het Uitgaven scherm met alle configuratie-opties en genummerde annotaties</p>
             
             <div class="example-files-list">


### PR DESCRIPTION
- Remove max-width constraint from .app-screenshot class
- Images now display at native size on desktop
- Add media query to constrain images to 100% width on mobile (≤768px)
- Remove unused .app-screenshot-wide CSS class
- Update how-to-plan.html and nl/how-to-plan.html to use .app-screenshot instead of .app-screenshot-wide