### PR TITLE
Optimize compound interest calculator layout for desktop

### DIFF
--- a/assets/css/tools/compound-interest.css
+++ b/assets/css/tools/compound-interest.css
@@ -5,67 +5,115 @@
 
 .calculator-layout {
     display: flex;
-    gap: var(--space-xl);
-    margin-bottom: var(--space-xl);
+    gap: var(--space-md);
+    margin-bottom: var(--space-lg);
+    width: 100%;
+    align-items: stretch;
 }
 
-.calculator-layout #chart-container {
+.left-column {
+    flex: 0 0 calc(65% - var(--space-md) / 2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+    width: 100%;
+}
+
+.sliders-column {
+    flex: 0 0 calc(35% - var(--space-md) / 2);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+#chart-container {
+    background: var(--color-bg-dark-card);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm);
     flex: 1;
-    min-height: 450px;
-    max-height: 500px;
+    min-height: 0;
+    max-height: 450px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
 }
 
-.calculator-layout #chart {
-    height: 450px;
-    max-height: 500px;
+#chart {
+    width: 100%;
+    height: 400px;
+    max-height: 450px;
 }
 
-.calculator-layout .results-grid {
-    flex: 0 0 30%;
-    margin: 0;
+.results-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--space-md);
 }
 
-.calculator-controls {
+.results-grid .result-card {
+    margin-bottom: 0;
+}
+
+.result-card {
+    background: var(--color-bg-dark-elevated);
+    padding: var(--space-md);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    text-align: center;
+}
+
+.result-label {
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+    margin-bottom: var(--space-xs);
+}
+
+.result-value {
+    color: var(--color-accent-yellow);
+    font-size: 1.5rem;
+    font-weight: 700;
+    font-family: var(--font-heading);
+}
+
+.slider-group {
     background: var(--color-bg-dark-card);
     border: 1px solid rgba(255, 255, 255, 0.05);
     border-left: 3px solid var(--color-accent-blue);
     border-radius: var(--radius-md);
-    padding: var(--space-lg);
-    margin-top: var(--space-lg);
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    gap: var(--space-md) var(--space-lg);
-    align-items: center;
+    padding: var(--space-md);
     width: 100%;
+    box-sizing: border-box;
 }
 
-.slider-group {
-    display: contents;
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-sm);
 }
 
 .slider-label {
-    justify-self: end;
-    text-align: right;
-    padding-right: var(--space-md);
     font-weight: 600;
     color: var(--color-text-primary);
+    font-size: 0.95rem;
+}
+
+.slider-display {
+    color: var(--color-accent-yellow);
+    font-weight: 700;
     font-size: 1rem;
 }
 
 .slider-input {
     position: relative;
-    padding: var(--space-md) 0;
-}
-
-.slider-display {
-    justify-self: start;
-    color: var(--color-accent-yellow);
-    font-weight: 700;
-    font-size: 1.2rem;
+    padding: var(--space-sm) 0;
 }
 
 .slider {
     width: 100%;
+    box-sizing: border-box;
     height: 8px;
     border-radius: 4px;
     background: var(--color-bg-dark-elevated);
@@ -126,55 +174,6 @@
     background: var(--color-accent-blue);
 }
 
-.results-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-lg);
-}
-
-.results-grid .result-card {
-    margin-bottom: 0;
-}
-
-.result-card {
-    background: var(--color-bg-dark-elevated);
-    padding: var(--space-lg);
-    border-radius: var(--radius-md);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    text-align: center;
-}
-
-.result-label {
-    color: var(--color-text-secondary);
-    font-size: 0.9rem;
-    margin-bottom: var(--space-sm);
-}
-
-.result-value {
-    color: var(--color-accent-yellow);
-    font-size: 1.8rem;
-    font-weight: 700;
-    font-family: var(--font-heading);
-}
-
-#chart-container {
-    background: var(--color-bg-dark-card);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: var(--radius-md);
-    padding: var(--space-xl);
-    min-height: 450px;
-    max-height: 500px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-#chart {
-    width: 100%;
-    height: 450px;
-    max-height: 500px;
-}
-
 .explanation-section {
     background: var(--color-bg-dark-card);
     border: 1px solid rgba(255, 255, 255, 0.05);
@@ -220,10 +219,14 @@
         flex-direction: column;
     }
     
-    .calculator-layout .results-grid {
+    .left-column,
+    .sliders-column {
         flex: auto;
         width: 100%;
-        margin-bottom: var(--space-lg);
+    }
+    
+    .results-grid {
+        grid-template-columns: 1fr;
     }
 }
 
@@ -251,10 +254,6 @@
     #chart-container {
         min-height: 350px;
         max-height: 400px;
-        padding: var(--space-lg);
-    }
-    
-    .calculator-controls {
         padding: var(--space-lg);
     }
 }

--- a/compound-interest.html
+++ b/compound-interest.html
@@ -20,57 +20,67 @@ description: "Interactive compound interest calculator. See how your investments
 
 <section class="calculator-container">
     <div class="calculator-layout animate-fade-in">
-        <div id="chart-container">
-            <div id="chart"></div>
+        <div class="left-column">
+            <div class="results-grid animate-fade-in">
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalValue }}</div>
+                    <div class="result-value" id="total-value">$0</div>
+                </div>
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalContributions }}</div>
+                    <div class="result-value" id="total-contributions">$0</div>
+                </div>
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalInterest }}</div>
+                    <div class="result-value" id="total-interest">$0</div>
+                </div>
+            </div>
+
+            <div id="chart-container">
+                <div id="chart"></div>
+            </div>
         </div>
 
-        <div class="results-grid animate-fade-in">
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalValue }}</div>
-                <div class="result-value" id="total-value">$0</div>
+        <div class="sliders-column animate-fade-in">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.initial }}</span>
+                    <span class="slider-display" id="initial-value">$0</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="initial" class="slider" min="0" max="100000" step="2500" value="0">
+                </div>
             </div>
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalContributions }}</div>
-                <div class="result-value" id="total-contributions">$0</div>
-            </div>
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalInterest }}</div>
-                <div class="result-value" id="total-interest">$0</div>
-            </div>
-        </div>
-    </div>
 
-    <div class="calculator-controls animate-fade-in">
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.initial }}</span>
-            <div class="slider-input">
-                <input type="range" id="initial" class="slider" min="0" max="100000" step="2500" value="0">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.monthly }}</span>
+                    <span class="slider-display" id="monthly-value">$100</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="monthly" class="slider" min="0" max="1000" step="25" value="100">
+                </div>
             </div>
-            <span class="slider-display" id="initial-value">$0</span>
-        </div>
 
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.monthly }}</span>
-            <div class="slider-input">
-                <input type="range" id="monthly" class="slider" min="0" max="1000" step="25" value="100">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.interest }}</span>
+                    <span class="slider-display" id="interest-value">7.0%</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="interest" class="slider" min="0" max="20" step="0.5" value="7">
+                </div>
             </div>
-            <span class="slider-display" id="monthly-value">$100</span>
-        </div>
 
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.interest }}</span>
-            <div class="slider-input">
-                <input type="range" id="interest" class="slider" min="0" max="20" step="0.5" value="7">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.years }}</span>
+                    <span class="slider-display" id="years-value">20</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="years" class="slider" min="1" max="60" step="1" value="20">
+                </div>
             </div>
-            <span class="slider-display" id="interest-value">7.0%</span>
-        </div>
-
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.years }}</span>
-            <div class="slider-input">
-                <input type="range" id="years" class="slider" min="1" max="60" step="1" value="20">
-            </div>
-            <span class="slider-display" id="years-value">20</span>
         </div>
     </div>
 </section>

--- a/nl/compound-interest.html
+++ b/nl/compound-interest.html
@@ -20,57 +20,67 @@ description: "Interactieve samengestelde rente calculator. Zie hoe je investerin
 
 <section class="calculator-container">
     <div class="calculator-layout animate-fade-in">
-        <div id="chart-container">
-            <div id="chart"></div>
+        <div class="left-column">
+            <div class="results-grid animate-fade-in">
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalValue }}</div>
+                    <div class="result-value" id="total-value">€0</div>
+                </div>
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalContributions }}</div>
+                    <div class="result-value" id="total-contributions">€0</div>
+                </div>
+                <div class="result-card">
+                    <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalInterest }}</div>
+                    <div class="result-value" id="total-interest">€0</div>
+                </div>
+            </div>
+
+            <div id="chart-container">
+                <div id="chart"></div>
+            </div>
         </div>
 
-        <div class="results-grid animate-fade-in">
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalValue }}</div>
-                <div class="result-value" id="total-value">€0</div>
+        <div class="sliders-column animate-fade-in">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.initial }}</span>
+                    <span class="slider-display" id="initial-value">€0</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="initial" class="slider" min="0" max="100000" step="2500" value="0">
+                </div>
             </div>
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalContributions }}</div>
-                <div class="result-value" id="total-contributions">€0</div>
-            </div>
-            <div class="result-card">
-                <div class="result-label">{{ lang_data.tools.compoundInterestCalc.totalInterest }}</div>
-                <div class="result-value" id="total-interest">€0</div>
-            </div>
-        </div>
-    </div>
 
-    <div class="calculator-controls animate-fade-in">
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.initial }}</span>
-            <div class="slider-input">
-                <input type="range" id="initial" class="slider" min="0" max="100000" step="2500" value="0">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.monthly }}</span>
+                    <span class="slider-display" id="monthly-value">€100</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="monthly" class="slider" min="0" max="1000" step="25" value="100">
+                </div>
             </div>
-            <span class="slider-display" id="initial-value">€0</span>
-        </div>
 
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.monthly }}</span>
-            <div class="slider-input">
-                <input type="range" id="monthly" class="slider" min="0" max="1000" step="25" value="100">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.interest }}</span>
+                    <span class="slider-display" id="interest-value">7,0%</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="interest" class="slider" min="0" max="20" step="0.5" value="7">
+                </div>
             </div>
-            <span class="slider-display" id="monthly-value">€100</span>
-        </div>
 
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.interest }}</span>
-            <div class="slider-input">
-                <input type="range" id="interest" class="slider" min="0" max="20" step="0.5" value="7">
+            <div class="slider-group">
+                <div class="slider-header">
+                    <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.years }}</span>
+                    <span class="slider-display" id="years-value">20</span>
+                </div>
+                <div class="slider-input">
+                    <input type="range" id="years" class="slider" min="1" max="60" step="1" value="20">
+                </div>
             </div>
-            <span class="slider-display" id="interest-value">7,0%</span>
-        </div>
-
-        <div class="slider-group">
-            <span class="slider-label">{{ lang_data.tools.compoundInterestCalc.years }}</span>
-            <div class="slider-input">
-                <input type="range" id="years" class="slider" min="1" max="60" step="1" value="20">
-            </div>
-            <span class="slider-display" id="years-value">20</span>
         </div>
     </div>
 </section>


### PR DESCRIPTION
- Restructured layout: 65% left column (values + chart), 35% right column (sliders)
- Values tiles above chart on left side
- Sliders stacked vertically on right with even distribution
- Reduced value card height and font size
- Reduced chart height to 400px
- Fixed alignment issues with flexbox calculations
- Sliders now span full width of their container
- Maintained responsive behavior for mobile devices