### PR TITLE
feat: Split privacy statement into website and app pages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -50,6 +50,8 @@ description: "Frequently asked questions about Finance Planner, the free F.I.R.E
         <h3>{{ lang_data.faq.privacy.export.question }}</h3>
         <p>{{ lang_data.faq.privacy.export.answer }}</p>
     </div>
+
+    <p style="margin-top: 1.5rem;"><em>For more details, see our <a href="privacy-app.html">App Privacy Statement</a>.</em></p>
 </section>
 
 <section class="animate-fade-in section">

--- a/more-info.html
+++ b/more-info.html
@@ -18,7 +18,7 @@ description: "Learn more about Finance Planner features, deposit and withdrawal 
         <li><strong>No Cloud Sync:</strong> Your financial plans are yours alone and remain completely private</li>
         <li><strong>Full Control:</strong> You decide what to do with your data—export, backup, or delete it anytime</li>
     </ul>
-    <p>Note: The mobile apps use ads to remain free. Ad providers (AdMob) may collect anonymous usage data as described in our Privacy Statement.</p>
+    <p>Note: The mobile apps use ads to remain free. Ad providers (AdMob) may collect anonymous usage data as described in our <a href="privacy-app.html">App Privacy Statement</a>.</p>
 </section>
 
 <section class="animate-fade-in section">

--- a/nl/faq.html
+++ b/nl/faq.html
@@ -50,6 +50,8 @@ description: "Veelgestelde vragen over Finance Planner, de gratis F.I.R.E. plann
         <h3>{{ lang_data.faq.privacy.export.question }}</h3>
         <p>{{ lang_data.faq.privacy.export.answer }}</p>
     </div>
+
+    <p style="margin-top: 1.5rem;"><em>Voor meer details, zie onze <a href="privacy-app.html">App Privacyverklaring</a>.</em></p>
 </section>
 
 <section class="animate-fade-in section">

--- a/nl/more-info.html
+++ b/nl/more-info.html
@@ -18,7 +18,7 @@ description: "Leer meer over Finance Planner functies, storting- en opnameplanni
         <li><strong>Geen cloud sync:</strong> Je financiële plannen zijn van jou alleen en blijven volledig privé</li>
         <li><strong>Volledige controle:</strong> Jij bepaalt wat je met je gegevens doet—exporteer, back-up of verwijder ze op elk moment</li>
     </ul>
-    <p>Let op: De mobiele apps gebruiken advertenties om gratis te blijven. Advertentieproviders (AdMob) kunnen anonieme gebruiksgegevens verzamelen zoals beschreven in onze Privacyverklaring.</p>
+    <p>Let op: De mobiele apps gebruiken advertenties om gratis te blijven. Advertentieproviders (AdMob) kunnen anonieme gebruiksgegevens verzamelen zoals beschreven in onze <a href="privacy-app.html">App Privacyverklaring</a>.</p>
 </section>
 
 <section class="animate-fade-in section">

--- a/nl/privacy-app.html
+++ b/nl/privacy-app.html
@@ -1,0 +1,61 @@
+---
+layout: default
+lang: nl
+asset_prefix: "../"
+title: "App Privacyverklaring - Finance Planner"
+description: "Privacyverklaring voor de Finance Planner mobiele app. Al jouw financiële gegevens blijven 100% op jouw apparaat. Wij verzamelen of versturen nooit jouw financiële informatie."
+---
+<section class="animate-fade-in hero">
+    <h1 class="animate-from-top" data-animate-delay="100ms">App Privacyverklaring</h1>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">Voor Finance Planner Mobiele App (iOS & Android)</p>
+    <p><strong>Laatst bijgewerkt:</strong> 2 januari 2026</p>
+    <p style="margin-top: 1rem;"><a href="privacy.html">← Terug naar Privacyverklaring</a></p>
+</section>
+
+<section class="animate-fade-in section">
+    <div class="feature-card" style="background: #1a237e; color: white; border-left: 4px solid #5c6bc0;">
+        <h2 style="margin-top: 0; color: white;">📱 Jouw financiële gegevens verlaten nooit jouw apparaat</h2>
+        <p><strong>Wij verzamelen, bewaren of versturen GEEN financiële informatie.</strong></p>
+        <p>Geen cloud. Geen servers. Geen gegevensverzameling.</p>
+    </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Wat wij NIET doen</h2>
+    <ul>
+        <li>❌ Wij verzamelen GEEN inkomsten, uitgaven of besparingen</li>
+        <li>❌ Wij bewaren GEEN berekeningen of financiële plannen</li>
+        <li>❌ Wij versturen GEEN gegevens naar onze servers</li>
+        <li>❌ Wij volgen GEEN gebruikersinteracties</li>
+        <li>❌ Wij verzamelen GEEN persoonlijke financiële informatie</li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Externe diensten</h2>
+    
+    <h3>Google AdMob</h3>
+    <p>Google AdMob toont advertenties in de app om deze gratis te houden. AdMob kan verzamelen:</p>
+    <ul>
+        <li>Apparaattype en besturingssysteem</li>
+        <li>Advertentie-interactiegegevens (welke advertenties u bekijkt of waarop u klikt)</li>
+    </ul>
+    <p><strong>Dit is anonieme data—nooit uw financiële informatie.</strong></p>
+    <p>Meer informatie: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google Privacy Policy</a></p>
+    
+    <h4>Hoe u zich kunt afmelden</h4>
+    <ul>
+        <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads-instellingen</a></li>
+        <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA)</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Gegevensbeveiliging</h2>
+    <p>Uw financiële gegevens worden opgeslagen met de ingebouwde beveiligingsfuncties van uw apparaat. U kunt uw gegevens exporteren of back-uppen via het Delen-menu in de app.</p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Gerelateerde privacyverklaringen</h2>
+    <p>Bezoekt u onze website? Bekijk onze <a href="privacy-website.html">Website Privacyverklaring</a> voor informatie over cookies en analytics op financeplannerapp.com.</p>
+</section>

--- a/nl/privacy-website.html
+++ b/nl/privacy-website.html
@@ -1,0 +1,85 @@
+---
+layout: default
+lang: nl
+asset_prefix: "../"
+title: "Website Privacyverklaring - Finance Planner"
+description: "Privacyverklaring voor de Finance Planner website (financeplannerapp.com). Leer over cookies, analytics en advertenties op onze website."
+---
+<section class="animate-fade-in hero">
+    <h1 class="animate-from-top" data-animate-delay="100ms">Website Privacyverklaring</h1>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">Privacy voor financeplannerapp.com</p>
+    <p><strong>Laatst bijgewerkt:</strong> 2 januari 2026</p>
+    <p style="margin-top: 1rem;"><a href="privacy.html">← Terug naar Privacyverklaring</a></p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Informatie die wij verzamelen</h2>
+    <p>Wanneer u onze website bezoekt, kunnen wij de volgende informatie verzamelen via externe diensten:</p>
+    <ul>
+        <li>Internet Protocol (IP) adres</li>
+        <li>Browsertype en -versie</li>
+        <li>Pagina's die u bezoekt op onze website</li>
+        <li>Tijd en datum van uw bezoek</li>
+        <li>De website die u naar ons heeft verwezen</li>
+    </ul>
+    <p><strong>Deze informatie is anoniem en niet gekoppeld aan uw persoonlijke identiteit.</strong></p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Hoe wij informatie gebruiken</h2>
+    <p>De beperkte informatie die wordt verzameld, wordt gebruikt voor:</p>
+    <ul>
+        <li>Het weergeven van relevante advertenties om de dienst gratis te houden</li>
+        <li>Het begrijpen van hoe bezoekers onze website gebruiken om de gebruikerservaring te verbeteren</li>
+        <li>Het onderhouden van de website functionaliteit (bijv. taalvoorkeuren)</li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Externe diensten</h2>
+    
+    <h3>Google Analytics</h3>
+    <p>Wij gebruiken Google Analytics om te begrijpen hoe bezoekers interacteren met onze website. Dit helpt ons content en gebruikerservaring te verbeteren.</p>
+    
+    <h3>Google AdSense</h3>
+    <p>Wij gebruiken Google AdSense om advertenties weer te geven op onze website. AdSense gebruikt cookies om advertenties weer te geven op basis van uw surfgedrag over websites heen.</p>
+    
+    <h4>Hoe u zich kunt afmelden voor gepersonaliseerde reclame</h4>
+    <p>U kunt zich afmelden voor gepersonaliseerde reclame door te bezoeken:</p>
+    <ul>
+        <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads-instellingen</a></li>
+        <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA)</a></li>
+        <li><a href="http://www.networkadvertising.org/choices/" target="_blank" rel="noopener">Network Advertising Initiative (NAI)</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Cookies</h2>
+    <div class="example-files-list">
+        <div class="animate-from-right example-file-card" data-animate-delay="200ms">
+            <h4>Essentiële cookies</h4>
+            <p>Noodzakelijk voor website functionaliteit. Ze maken basisfuncties mogelijk zoals taalselectie en onthouden uw voorkeuren.</p>
+        </div>
+        
+        <div class="animate-from-left example-file-card" data-animate-delay="100ms">
+            <h4>Advertentiecookies</h4>
+            <p>Gebruikt door Google AdSense om relevante advertenties weer te geven op basis van uw surfgedrag.</p>
+        </div>
+    </div>
+    
+    <p style="margin-top: 1rem;">U kunt cookies beheren via uw browserinstellingen. Het uitschakelen van cookies kan de website functionaliteit beïnvloeden.</p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Uw rechten</h2>
+    <ul>
+        <li><strong>Cookies:</strong> Beheer cookievoorkeuren via uw browserinstellingen</li>
+        <li><strong>Gepersonaliseerde advertenties:</strong> Meld u af met de links in de sectie "Externe diensten" hierboven</li>
+        <li><strong>Vragen:</strong> Als u vragen heeft, <a href="contact.html">neem dan contact met ons op</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Gerelateerde privacyverklaringen</h2>
+    <p>Gebruikt u de Finance Planner mobiele app? Bekijk onze <a href="privacy-app.html">App Privacyverklaring</a> voor informatie over gegevensverwerking in de app.</p>
+</section>

--- a/nl/privacy.html
+++ b/nl/privacy.html
@@ -3,166 +3,44 @@ layout: default
 lang: nl
 asset_prefix: "../"
 title: "Privacyverklaring - Finance Planner"
-description: "Privacyverklaring voor Finance Planner. Leer hoe wij uw gegevens beschermen en welke informatie wordt verzameld door externe advertentiediensten."
+description: "Privacyverklaring voor Finance Planner. Jouw financiële gegevens blijven 100% op jouw apparaat. Leer over onze website en app privacy praktijken."
 ---
 <section class="animate-fade-in hero">
     <h1 class="animate-from-top" data-animate-delay="100ms">Privacyverklaring</h1>
-            <p class="subtitle animate-from-top" data-animate-delay="200ms">Jouw privacy is onze prioriteit</p>
-            <p><strong>Laatst bijgewerkt:</strong> 2 januari 2026</p>
-        </section>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">Jouw privacy is onze prioriteit</p>
+    <p><strong>Laatst bijgewerkt:</strong> 2 januari 2026</p>
+</section>
 
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Inleiding</h2>
-            <p>Finance Planner ("wij," "ons," of "onze") is toegewijd aan het beschermen van uw privacy. Deze privacyverklaring legt uit hoe informatie wordt verzameld, gebruikt en openbaar gemaakt wanneer u onze website financeplannerapp.com (de "Website") bezoekt of onze mobiele applicaties (de "App") gebruikt.</p>
-            <p><strong>Het belangrijkste om te weten:</strong> Al uw persoonlijke financiële gegevens en berekeningen blijven 100% op uw apparaat. Wij verzamelen, bewaren of versturen uw financiële informatie niet naar onze servers of derden.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Informatie die wij verzamelen</h2>
-            
-            <h3>Persoonlijke financiële gegevens</h3>
-            <div class="animate-from-left feature-card" data-animate-delay="100ms" style="margin-bottom: 1.5rem;">
-                <span class="card-title">Wij verzamelen uw financiële gegevens NIET</span>
-                <span>Alle financiële informatie die u invoert in Finance Planner (inclusief inkomsten, uitgaven, besparingen, rekeningsaldi en alle berekeningen) wordt alleen lokaal op uw apparaat opgeslagen. Deze gegevens worden nooit verzonden naar onze servers of externe diensten.</span>
-            </div>
-
-            <h3>Website gebruiksgegevens</h3>
-            <p>Wanneer u onze website bezoekt, kunnen wij automatisch bepaalde informatie verzamelen, waaronder:</p>
-            <ul>
-                <li>Uw Internet Protocol (IP) adres</li>
-                <li>Browsertype en -versie</li>
-                <li>Pagina's die u bezoekt op onze website</li>
-                <li>Tijd en datum van uw bezoek</li>
-                <li>De website die u naar onze website heeft verwezen</li>
-            </ul>
-            <p>Deze informatie wordt verzameld door externe diensten (hieronder beschreven) en wordt alleen gebruikt voor analyse- en advertentiedoeleinden.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Externe diensten</h2>
-            
-            <h3>Google AdSense</h3>
-            <p>Wij gebruiken Google AdSense om advertenties weer te geven op onze website en in onze mobiele app. Google AdSense gebruikt cookies en vergelijkbare technologieën om advertenties te tonen op basis van uw eerdere bezoeken aan onze website of andere websites.</p>
-            <p>Het gebruik van advertentiecookies door Google stelt het bedrijf en zijn partners in staat om advertenties aan u te tonen op basis van uw bezoek aan onze website en/of andere websites op internet. Dit staat bekend als "gepersonaliseerde reclame" of "interesse-gebaseerde reclame."</p>
-            
-            <h4>Hoe u zich kunt afmelden voor gepersonaliseerde reclame</h4>
-            <p>U kunt zich afmelden voor gepersonaliseerde reclame door de volgende links te bezoeken:</p>
-            <ul>
-                <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads-instellingen</a></li>
-                <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA) consumentenkeuze-pagina</a></li>
-                <li><a href="http://www.networkadvertising.org/choices/" target="_blank" rel="noopener">Network Advertising Initiative (NAI) opt-out-pagina</a></li>
-            </ul>
-            <p>Let op: afmelden betekent niet dat u geen advertenties meer ziet; het betekent dat de advertenties die u ziet niet worden gepersonaliseerd op basis van uw interesses.</p>
-
-            <h3>Google AdMob (mobiele app)</h3>
-            <p>In onze mobiele applicaties gebruiken wij Google AdMob om advertenties weer te geven. AdMob kan informatie verzamelen en gebruiken zoals:</p>
-            <ul>
-                <li>Apparaatinformatie (apparaattype, besturingssysteem, apparaat-ID's)</li>
-                <li>App-gebruiksgegevens (welke functies u gebruikt, hoe lang u de app gebruikt)</li>
-                <li>Advertentie-interactiegegevens (welke advertenties u bekijkt of waarop u klikt)</li>
-            </ul>
-            <p>Voor meer informatie over hoe Google gegevens gebruikt, raadpleeg het privacybeleid van Google op <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">https://policies.google.com/privacy</a></p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Cookies en volgtechnologieën</h2>
-            <p>Onze website en externe diensten gebruiken cookies en vergelijkbare volgtechnologieën. Cookies zijn kleine tekstbestanden die op uw apparaat worden opgeslagen en die ons en onze partners helpen u een betere ervaring te bieden.</p>
-            
-            <h3>Soorten cookies die wij gebruiken:</h3>
-            <div class="example-files-list">
-                <div class="animate-from-right example-file-card" data-animate-delay="200ms">
-                    <h4>Essentiële cookies</h4>
-                    <p>Deze cookies zijn noodzakelijk voor het correct functioneren van de website. Ze maken basisfuncties mogelijk zoals taalselectie en onthouden uw voorkeuren.</p>
-                </div>
-                
-                <div class="animate-from-left example-file-card" data-animate-delay="100ms">
-                    <h4>Advertentiecookies</h4>
-                    <p>Deze cookies worden gebruikt door Google AdSense en andere advertentiepartners om u relevante advertenties te tonen op basis van uw surfgedrag.</p>
-                </div>
-            </div>
-            
-            <p>U kunt cookies beheren en controleren via uw browserinstellingen. Let op: het uitschakelen van cookies kan van invloed zijn op de functionaliteit van onze website en de advertenties die u ziet.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Hoe wij informatie gebruiken</h2>
-            <p>De beperkte informatie die wij verzamelen (via externe diensten) wordt gebruikt voor:</p>
-            <ul>
-                <li>Het weergeven van relevante advertenties om de dienst gratis te houden</li>
-                <li>Het begrijpen van hoe bezoekers onze website gebruiken om de gebruikerservaring te verbeteren</li>
-                <li>Het onderhouden van de functionaliteit van de website (bijv. taalvoorkeuren)</li>
-            </ul>
-            <p><strong>Herinnering:</strong> Uw financiële gegevens (inkomsten, uitgaven, besparingen, berekeningen) worden nooit verzameld, verzonden of gebruikt door ons of een derde partij.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Gegevensdeling en openbaarmaking</h2>
-            <p>Wij verkopen, verhandelen of verhuren uw persoonlijke informatie niet. De enige gegevensdeling die plaatsvindt is:</p>
-            <ul>
-                <li><span class="list-label">Google AdSense/AdMob:</span> Anonieme gebruiksgegevens en advertentie-ID's worden gedeeld met Google om advertenties weer te geven.</li>
-                <li><span class="list-label">Juridische vereisten:</span> Wij kunnen informatie openbaar maken indien vereist door de wet of om onze rechten te beschermen.</li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Gegevensbeveiliging</h2>
-            <p>Uw financiële gegevens worden alleen op uw apparaat opgeslagen, met behulp van de ingebouwde beveiligingsfuncties van uw apparaat. Wij hebben geen toegang tot deze gegevens en kunnen deze niet ophalen.</p>
-            <p>Voor de beperkte websitegebruiksgegevens die worden verzameld door externe diensten, vertrouwen wij op de beveiligingsmaatregelen van die diensten. Wij raden u aan hun privacybeleid te bekijken.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Privacy van kinderen</h2>
-            <p>Finance Planner is niet bedoeld voor gebruik door kinderen onder de leeftijd van 13 jaar (of de toepasselijke toestemmingsleeftijd in uw jurisdictie). Wij verzamelen niet bewust persoonlijke informatie van kinderen.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Internationale gebruikers</h2>
-            <p>Finance Planner is wereldwijd beschikbaar. Als u onze website of app bezoekt van buiten de Europese Unie of de Verenigde Staten, houd er dan rekening mee dat informatie die wordt verzameld door externe diensten kan worden overgedragen naar en verwerkt in landen met andere privacywetten.</p>
-            <p><strong>AVG-naleving (EU-gebruikers):</strong> Als u inwoner bent van de Europese Unie, heeft u het recht om persoonlijke informatie die over u is verzameld, in te zien, te corrigeren of te verwijderen. Aangezien uw financiële gegevens op uw apparaat blijven, heeft u daar volledige controle over. Voor gegevens die worden verzameld door derden (zoals Google), raadpleeg hun privacybeleid en opt-out-mechanismen.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Uw rechten en keuzes</h2>
-            <p>U heeft de volgende rechten met betrekking tot uw gegevens:</p>
-            <ul>
-                <li><span class="list-label">Financiële gegevens:</span> U heeft volledige controle. U kunt uw financiële gegevens op elk moment exporteren, back-uppen of verwijderen via de app.</li>
-                <li><span class="list-label">Cookies:</span> U kunt cookievoorkeuren beheren via uw browserinstellingen.</li>
-                <li><span class="list-label">Gepersonaliseerde advertenties:</span> U kunt zich afmelden voor gepersonaliseerde reclame met behulp van de links in de sectie "Externe diensten" hierboven.</li>
-                <li><span class="list-label">Vragen:</span> Als u vragen heeft over uw gegevens of deze privacyverklaring, neem dan <a href="contact.html">contact met ons op</a>.</li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Wijzigingen in deze privacyverklaring</h2>
-            <p>Wij kunnen deze privacyverklaring van tijd tot tijd bijwerken. Wanneer wij dat doen, werken wij de datum "Laatst bijgewerkt" bovenaan deze pagina bij. Wij moedigen u aan om deze privacyverklaring periodiek te bekijken om op de hoogte te blijven van hoe wij uw informatie beschermen.</p>
-            <p>Significante wijzigingen worden gecommuniceerd via onze website of app.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Contact opnemen</h2>
-            <p>Als u vragen heeft over deze privacyverklaring of hoe uw gegevens worden behandeld, neem dan contact met ons op:</p>
-            <ul>
-                <li><span class="list-label">GitHub Discussions:</span> <a href="https://github.com/juuul/FinancePlanner/discussions" target="_blank" rel="noopener">Sluit je aan bij onze gemeenschap</a></li>
-                <li><span class="list-label">Contactpagina:</span> <a href="contact.html">Bezoek onze contactpagina</a></li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Links naar derden</h2>
-            <p>Onze website kan links bevatten naar websites van derden (zoals app stores, sociale media en YouTube). Wij zijn niet verantwoordelijk voor de privacypraktijken van deze externe sites. Wij moedigen u aan om hun privacybeleid te bekijken voordat u persoonlijke informatie verstrekt.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Samenvatting</h2>
-            <div class="animate-from-right feature-card" data-animate-delay="200ms">
-                <span class="card-title">Wat u moet weten:</span>
-                <ul style="margin-top: 1rem; text-align: left;">
-                    <li>✅ Uw financiële gegevens blijven 100% op uw apparaat—wij zien ze nooit</li>
-                    <li>✅ Wij gebruiken advertenties (Google AdSense/AdMob) om de dienst gratis te houden</li>
-                    <li>✅ Alleen anonieme gebruiksgegevens worden verzameld door advertentiepartners</li>
-                    <li>✅ U kunt zich op elk moment afmelden voor gepersonaliseerde advertenties</li>
-                    <li>✅ U heeft volledige controle over uw financiële gegevens</li>
-                </ul>
-            </div>
-        </section>
+<section class="animate-fade-in section">
+    <div class="feature-card" style="background: #1a237e; color: white; border-left: 4px solid #5c6bc0;">
+        <h2 style="margin-top: 0; color: white;">Jouw financiële gegevens zijn 100% privé</h2>
+        <ul style="margin-bottom: 0;">
+            <li>✅ Jouw financiële gegevens blijven 100% op jouw apparaat</li>
+            <li>✅ Wij verzamelen, bewaren of versturen nooit jouw financiële informatie</li>
+            <li>✅ Jij hebt volledige controle over jouw gegevens</li>
+        </ul>
     </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Website vs. App</h2>
+    <p>Finance Planner bestaat uit twee onderdelen, elk met eigen privacy-implicaties:</p>
+    <div class="example-files-list" style="margin-top: 1.5rem;">
+        <div class="animate-from-right example-file-card" data-animate-delay="100ms">
+            <h4>🌐 Website (financeplannerapp.com)</h4>
+            <p>Onze informatieve website gebruikt analytics- en advertentiecookies om de gebruikerservaring te verbeteren en de dienst gratis te houden.</p>
+            <a href="privacy-website.html" class="btn btn-secondary" style="margin-top: 1rem;">Bekijk Website Privacy</a>
+        </div>
+        
+        <div class="animate-from-left example-file-card" data-animate-delay="200ms">
+            <h4>📱 Mobiele App (iOS & Android)</h4>
+            <p>De Finance Planner app slaat al jouw financiële gegevens lokaal op jouw apparaat op. Wij verzamelen of versturen nooit jouw financiële informatie.</p>
+            <a href="privacy-app.html" class="btn btn-secondary" style="margin-top: 1rem;">Bekijk App Privacy</a>
+        </div>
+    </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Onze privacy-toezegging</h2>
+    <p>Privacy is fundamenteel voor financiële planning. Wij geloven dat jij volledige controle moet hebben over jouw financiële informatie, daarom blijven al jouw gegevens op jouw apparaat en worden ze nooit gedeeld met ons of derden.</p>
+</section>

--- a/privacy-app.html
+++ b/privacy-app.html
@@ -1,0 +1,61 @@
+---
+layout: default
+lang: en
+asset_prefix: ""
+title: "App Privacy Statement - Finance Planner"
+description: "Privacy statement for the Finance Planner mobile app. All your financial data stays 100% on your device. We never collect or transmit your financial information."
+---
+<section class="animate-fade-in hero">
+    <h1 class="animate-from-top" data-animate-delay="100ms">App Privacy Statement</h1>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">For Finance Planner Mobile App (iOS & Android)</p>
+    <p><strong>Last Updated:</strong> January 2, 2026</p>
+    <p style="margin-top: 1rem;"><a href="privacy.html">← Back to Privacy Statement</a></p>
+</section>
+
+<section class="animate-fade-in section">
+    <div class="feature-card" style="background: #1a237e; color: white; border-left: 4px solid #5c6bc0;">
+        <h2 style="margin-top: 0; color: white;">📱 Your Financial Data Never Leaves Your Device</h2>
+        <p><strong>We do NOT collect, store, or transmit any financial information.</strong></p>
+        <p>No cloud. No servers. No data collection.</p>
+    </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">What We DON'T Do</h2>
+    <ul>
+        <li>❌ We do NOT collect incomes, expenses, or savings</li>
+        <li>❌ We do NOT store calculations or financial plans</li>
+        <li>❌ We do NOT send data to our servers</li>
+        <li>❌ We do NOT track user interactions</li>
+        <li>❌ We do NOT collect any personal financial information</li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Third-Party Services</h2>
+    
+    <h3>Google AdMob</h3>
+    <p>Google AdMob displays advertisements in the app to keep it free. AdMob may collect:</p>
+    <ul>
+        <li>Device type and operating system</li>
+        <li>Ad interaction data (which ads you view or click)</li>
+    </ul>
+    <p><strong>This is anonymous data—never your financial information.</strong></p>
+    <p>Learn more: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google Privacy Policy</a></p>
+    
+    <h4>How to Opt Out</h4>
+    <ul>
+        <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads Settings</a></li>
+        <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA)</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Data Security</h2>
+    <p>Your financial data is stored using your device's built-in security features. You can export or backup your data through the app's Share menu.</p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Related Privacy Statements</h2>
+    <p>Visit our website? View our <a href="privacy-website.html">Website Privacy Statement</a> for information about cookies and analytics on financeplannerapp.com.</p>
+</section>

--- a/privacy-website.html
+++ b/privacy-website.html
@@ -1,0 +1,85 @@
+---
+layout: default
+lang: en
+asset_prefix: ""
+title: "Website Privacy Statement - Finance Planner"
+description: "Privacy statement for the Finance Planner website (financeplannerapp.com). Learn about cookies, analytics, and advertising on our website."
+---
+<section class="animate-fade-in hero">
+    <h1 class="animate-from-top" data-animate-delay="100ms">Website Privacy Statement</h1>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">Privacy for financeplannerapp.com</p>
+    <p><strong>Last Updated:</strong> January 2, 2026</p>
+    <p style="margin-top: 1rem;"><a href="privacy.html">← Back to Privacy Statement</a></p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Information We Collect</h2>
+    <p>When you visit our website, we may collect the following information through third-party services:</p>
+    <ul>
+        <li>Internet Protocol (IP) address</li>
+        <li>Browser type and version</li>
+        <li>Pages you visit on our website</li>
+        <li>Time and date of your visit</li>
+        <li>The website that referred you to us</li>
+    </ul>
+    <p><strong>This information is anonymous and is not linked to your personal identity.</strong></p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">How We Use Information</h2>
+    <p>The limited information collected is used for:</p>
+    <ul>
+        <li>Displaying relevant advertisements to keep the service free</li>
+        <li>Understanding how visitors use our website to improve user experience</li>
+        <li>Maintaining website functionality (e.g., language preferences)</li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Third-Party Services</h2>
+    
+    <h3>Google Analytics</h3>
+    <p>We use Google Analytics to understand how visitors interact with our website. This helps us improve content and user experience.</p>
+    
+    <h3>Google AdSense</h3>
+    <p>We use Google AdSense to display advertisements on our website. AdSense uses cookies to serve ads based on your browsing activity across websites.</p>
+    
+    <h4>How to Opt Out of Personalized Advertising</h4>
+    <p>You can opt out of personalized advertising by visiting:</p>
+    <ul>
+        <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads Settings</a></li>
+        <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA)</a></li>
+        <li><a href="http://www.networkadvertising.org/choices/" target="_blank" rel="noopener">Network Advertising Initiative (NAI)</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Cookies</h2>
+    <div class="example-files-list">
+        <div class="animate-from-right example-file-card" data-animate-delay="200ms">
+            <h4>Essential Cookies</h4>
+            <p>Necessary for website functionality. They enable basic functions like language selection and remember your preferences.</p>
+        </div>
+        
+        <div class="animate-from-left example-file-card" data-animate-delay="100ms">
+            <h4>Advertising Cookies</h4>
+            <p>Used by Google AdSense to show relevant ads based on your browsing activity.</p>
+        </div>
+    </div>
+    
+    <p style="margin-top: 1rem;">You can manage cookies through your browser settings. Disabling cookies may affect website functionality.</p>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Your Rights</h2>
+    <ul>
+        <li><strong>Cookies:</strong> Manage cookie preferences through your browser settings</li>
+        <li><strong>Personalized Ads:</strong> Opt out using the links in the "Third-Party Services" section above</li>
+        <li><strong>Questions:</strong> If you have questions, please <a href="contact.html">contact us</a></li>
+    </ul>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Related Privacy Statements</h2>
+    <p>Use the Finance Planner mobile app? View our <a href="privacy-app.html">App Privacy Statement</a> for information about data handling in the app.</p>
+</section>

--- a/privacy.html
+++ b/privacy.html
@@ -2,167 +2,45 @@
 layout: default
 lang: en
 asset_prefix: ""
-title: "Privacy Policy - Finance Planner"
-description: "Privacy Policy for Finance Planner. Learn how we protect your data and what information is collected by third-party advertising services."
+title: "Privacy Statement - Finance Planner"
+description: "Privacy Statement for Finance Planner. Your financial data stays 100% on your device. Learn about our website and app privacy practices."
 ---
 <section class="animate-fade-in hero">
-    <h1 class="animate-from-top" data-animate-delay="100ms">Privacy Policy</h1>
-            <p class="subtitle animate-from-top" data-animate-delay="200ms">Your Privacy is Our Priority</p>
-            <p><strong>Last Updated:</strong> January 2, 2026</p>
-        </section>
+    <h1 class="animate-from-top" data-animate-delay="100ms">Privacy Statement</h1>
+    <p class="subtitle animate-from-top" data-animate-delay="200ms">Your Privacy is Our Priority</p>
+    <p><strong>Last Updated:</strong> January 2, 2026</p>
+</section>
 
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Introduction</h2>
-            <p>Finance Planner ("we," "our," or "us") is committed to protecting your privacy. This Privacy Policy explains how information is collected, used, and disclosed when you visit our website financeplannerapp.com (the "Website") or use our mobile applications (the "App").</p>
-            <p><strong>The most important thing to know:</strong> All your personal financial data and calculations remain 100% on your device. We do not collect, store, or transmit your financial information to our servers or any third parties.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Information We Collect</h2>
-            
-            <h3>Personal Financial Data</h3>
-            <div class="animate-from-left feature-card" data-animate-delay="100ms" style="margin-bottom: 1.5rem;">
-                <span class="card-title">We Do NOT Collect Your Financial Data</span>
-                <span>All financial information you enter into Finance Planner (including incomes, expenses, savings, account balances, and all calculations) is stored locally on your device only. This data is never transmitted to our servers or any third-party services.</span>
-            </div>
-
-            <h3>Website Usage Data</h3>
-            <p>When you visit our Website, we may collect certain information automatically, including:</p>
-            <ul>
-                <li>Your Internet Protocol (IP) address</li>
-                <li>Browser type and version</li>
-                <li>Pages you visit on our Website</li>
-                <li>Time and date of your visit</li>
-                <li>The website that referred you to our Website</li>
-            </ul>
-            <p>This information is collected by third-party services (described below) and is used only for analytics and advertising purposes.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Third-Party Services</h2>
-            
-            <h3>Google AdSense</h3>
-            <p>We use Google AdSense to display advertisements on our Website and in our mobile App. Google AdSense uses cookies and similar technologies to serve ads based on your prior visits to our Website or other websites.</p>
-            <p>Google's use of advertising cookies enables it and its partners to serve ads to you based on your visit to our Website and/or other sites on the Internet. This is known as "personalized advertising" or "interest-based advertising."</p>
-            
-            <h4>How to Opt Out of Personalized Advertising</h4>
-            <p>You can opt out of personalized advertising by visiting the following links:</p>
-            <ul>
-                <li><a href="https://www.google.com/settings/ads" target="_blank" rel="noopener">Google Ads Settings</a></li>
-                <li><a href="http://www.aboutads.info/choices/" target="_blank" rel="noopener">Digital Advertising Alliance (DAA) Consumer Choice Page</a></li>
-                <li><a href="http://www.networkadvertising.org/choices/" target="_blank" rel="noopener">Network Advertising Initiative (NAI) Opt-Out Page</a></li>
-            </ul>
-            <p>Please note that opting out does not mean you will no longer see ads; it means the ads you see will not be personalized based on your interests.</p>
-
-            <h3>Google AdMob (Mobile App)</h3>
-            <p>In our mobile applications, we use Google AdMob to display advertisements. AdMob may collect and use information such as:</p>
-            <ul>
-                <li>Device information (device type, operating system, device identifiers)</li>
-                <li>App usage data (which features you use, how long you use the app)</li>
-                <li>Ad interaction data (which ads you view or click)</li>
-            </ul>
-            <p>For more information about how Google uses data, please review Google's Privacy Policy at <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">https://policies.google.com/privacy</a></p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Cookies and Tracking Technologies</h2>
-            <p>Our Website and third-party services use cookies and similar tracking technologies. Cookies are small text files stored on your device that help us and our partners provide you with a better experience.</p>
-            
-            <h3>Types of Cookies We Use:</h3>
-            <div class="example-files-list">
-                <div class="animate-from-right example-file-card" data-animate-delay="200ms">
-                    <h4>Essential Cookies</h4>
-                    <p>These cookies are necessary for the Website to function properly. They enable basic functions like language selection and remember your preferences.</p>
-                </div>
-                
-                <div class="animate-from-left example-file-card" data-animate-delay="100ms">
-                    <h4>Advertising Cookies</h4>
-                    <p>These cookies are used by Google AdSense and other advertising partners to show you relevant ads based on your browsing activity.</p>
-                </div>
-            </div>
-            
-            <p>You can control and manage cookies through your browser settings. Please note that disabling cookies may affect the functionality of our Website and the ads you see.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">How We Use Information</h2>
-            <p>The limited information we collect (through third-party services) is used for:</p>
-            <ul>
-                <li>Displaying relevant advertisements to keep the service free</li>
-                <li>Understanding how visitors use our Website to improve user experience</li>
-                <li>Maintaining Website functionality (e.g., language preferences)</li>
-            </ul>
-            <p><strong>Reminder:</strong> Your financial data (incomes, expenses, savings, calculations) is never collected, transmitted, or used by us or any third party.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Data Sharing and Disclosure</h2>
-            <p>We do not sell, trade, or rent your personal information. The only data sharing that occurs is:</p>
-            <ul>
-                <li><span class="list-label">Google AdSense/AdMob:</span> Anonymous usage data and advertising identifiers are shared with Google to display ads.</li>
-                <li><span class="list-label">Legal Requirements:</span> We may disclose information if required by law or to protect our rights.</li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Data Security</h2>
-            <p>Your financial data is stored only on your device, using your device's built-in security features. We do not have access to this data and cannot retrieve it.</p>
-            <p>For the limited website usage data collected by third-party services, we rely on those services' security measures. We encourage you to review their privacy policies.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Children's Privacy</h2>
-            <p>Finance Planner is not intended for use by children under the age of 13 (or the applicable age of consent in your jurisdiction). We do not knowingly collect personal information from children.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">International Users</h2>
-            <p>Finance Planner is available worldwide. If you are accessing our Website or App from outside the European Union or United States, please be aware that information collected by third-party services may be transferred to and processed in countries with different privacy laws.</p>
-            <p><strong>GDPR Compliance (EU Users):</strong> If you are a resident of the European Union, you have the right to access, rectify, or delete personal information collected about you. Since your financial data remains on your device, you have complete control over it. For data collected by third parties (like Google), please refer to their privacy policies and opt-out mechanisms.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Your Rights and Choices</h2>
-            <p>You have the following rights regarding your data:</p>
-            <ul>
-                <li><span class="list-label">Financial Data:</span> You have complete control. You can export, back up, or delete your financial data at any time through the App.</li>
-                <li><span class="list-label">Cookies:</span> You can manage cookie preferences through your browser settings.</li>
-                <li><span class="list-label">Personalized Ads:</span> You can opt out of personalized advertising using the links provided in the "Third-Party Services" section above.</li>
-                <li><span class="list-label">Questions:</span> If you have questions about your data or this Privacy Policy, please <a href="contact.html">contact us</a>.</li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Changes to This Privacy Policy</h2>
-            <p>We may update this Privacy Policy from time to time. When we do, we will update the "Last Updated" date at the top of this page. We encourage you to review this Privacy Policy periodically to stay informed about how we protect your information.</p>
-            <p>Significant changes will be communicated through our Website or App.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Contact Us</h2>
-            <p>If you have any questions about this Privacy Policy or how your data is handled, please contact us:</p>
-            <ul>
-                <li><span class="list-label">GitHub Discussions:</span> <a href="https://github.com/juuul/FinancePlanner/discussions" target="_blank" rel="noopener">Join our community</a></li>
-                <li><span class="list-label">Contact Page:</span> <a href="contact.html">Visit our contact page</a></li>
-            </ul>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-left">Third-Party Links</h2>
-            <p>Our Website may contain links to third-party websites (such as app stores, social media, and YouTube). We are not responsible for the privacy practices of these external sites. We encourage you to review their privacy policies before providing any personal information.</p>
-        </section>
-
-        <section class="animate-fade-in section">
-            <h2 class="animate-from-right">Summary</h2>
-            <div class="animate-from-right feature-card" data-animate-delay="200ms">
-                <span class="card-title">What You Need to Know:</span>
-                <ul style="margin-top: 1rem; text-align: left;">
-                    <li>✅ Your financial data stays 100% on your device—we never see it</li>
-                    <li>✅ We use ads (Google AdSense/AdMob) to keep the service free</li>
-                    <li>✅ Only anonymous usage data is collected by advertising partners</li>
-                    <li>✅ You can opt out of personalized ads anytime</li>
-                    <li>✅ You have complete control over your financial data</li>
-                </ul>
-            </div>
-        </section>
+<section class="animate-fade-in section">
+    <div class="feature-card" style="background: #1a237e; color: white; border-left: 4px solid #5c6bc0;">
+        <h2 style="margin-top: 0; color: white;">Your Financial Data is 100% Private</h2>
+        <ul style="margin-bottom: 0;">
+            <li>✅ Your financial data stays 100% on your device</li>
+            <li>✅ We never collect, store, or transmit your financial information</li>
+            <li>✅ You have complete control over your data</li>
+        </ul>
     </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-left">Website vs. App</h2>
+    <p>Finance Planner consists of two parts, each with its own privacy implications:</p>
+    <div class="example-files-list" style="margin-top: 1.5rem;">
+        <div class="animate-from-right example-file-card" data-animate-delay="100ms">
+            <h4>🌐 Website (financeplannerapp.com)</h4>
+            <p>Our informational website uses analytics and advertising cookies to improve user experience and keep the service free.</p>
+            <a href="privacy-website.html" class="btn btn-secondary" style="margin-top: 1rem;">View Website Privacy</a>
+        </div>
+        
+        <div class="animate-from-left example-file-card" data-animate-delay="200ms">
+            <h4>📱 Mobile App (iOS & Android)</h4>
+            <p>The Finance Planner app stores all your financial data locally on your device. We never collect or transmit your financial information.</p>
+            <a href="privacy-app.html" class="btn btn-secondary" style="margin-top: 1rem;">View App Privacy</a>
+        </div>
+    </div>
+</section>
+
+<section class="animate-fade-in section">
+    <h2 class="animate-from-right">Our Privacy Commitment</h2>
+    <p>Privacy is fundamental to financial planning. We believe you should have complete control over your financial information, which is why all your data remains on your device and is never shared with us or any third parties.</p>
+</section>


### PR DESCRIPTION
- Create landing page (privacy.html) with core message and navigation
- Add website privacy page (privacy-website.html) for website-specific info
- Add app privacy page (privacy-app.html) for app-specific info
- Create Dutch versions (nl/privacy*.html) for all pages
- Update FAQ and more-info pages with links to app privacy
- Use dark blue feature cards for better readability
- Keep app privacy statement concise (no data collection emphasis)

Closes #184